### PR TITLE
Fix for Redhat 7 under strict mode

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class ntp::params {
         '2.rhel.pool.ntp.org iburst',
         '3.rhel.pool.ntp.org iburst',
       ]
+      $restrict = undef
     }
     default: {
       $package_name = 'ntp'


### PR DESCRIPTION
Under strict_variables, all variables need to be set, even if only to "undef"