### PR TITLE
Support all OSes based on RedHat 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class ntp::params {
 
-  case "${::operatingsystem}-${::operatingsystemmajrelease}" {
+  case "${::osfamily}-${::operatingsystemmajrelease}" {
     /^Gentoo/: {
       $package_name = 'net-misc/ntp'
       $service_name = 'ntpd'
@@ -16,7 +16,7 @@ class ntp::params {
         'default nomodify nopeer',
       ]
     }
-    /^(RedHat|CentOS)-7$/: {
+    'RedHat-7': {
       $package_name = 'chrony'
       $service_name = 'chronyd'
       $config_file = '/etc/chrony.conf'


### PR DESCRIPTION
Using $::osfamily instead of $::operatingsystem means we can support all OSes based on RedHat 7.